### PR TITLE
Fix: empty header line in magit popup window

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -259,6 +259,9 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
 (setq uniquify-separator "/")
 (setq uniquify-buffer-name-style 'post-forward-angle-brackets)
 (setq uniquify-after-kill-buffer-p t)
+;; Fix: empty header line in magit popup window makes its window insufficient of space
+;; to display all content
+(add-hook 'magit-popup-mode-hook (lambda () (setq-local header-line-format nil)))
 
 ;; Rules to control buffers show in tabs.
 (defun tabbar-filter-buffer-list ()


### PR DESCRIPTION
Which makes its window insufficient of space to display all content.
<img width="728" alt="screen shot 2018-09-19 at 11 17 43 pm" src="https://user-images.githubusercontent.com/13118647/45793997-74f79680-bc62-11e8-9621-6b12d5451183.png">

