### PR TITLE
Integration with semantic-stickfunc

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -1850,6 +1850,31 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
 
 (add-hook 'post-command-hook awesome-tab-adjust-buffer-order-function)
 
+;;; Awesome-Tab integration
+;;
+
+(defun awesome-tab-format-merge (left right-ratio)
+  (let* ((w (- (window-total-width)
+               (if (and window-system (eq 'right (get-scroll-bar-mode)))
+                   3 0)))
+         (right-len (truncate (* w right-ratio)))
+         (left-len (- w right-len 1)))
+    (if (< right-len 30)
+        ;; too small, tabbar only
+        (awesome-tab-line)
+      (list
+       (awesome-tab-truncate-string left-len left)
+       (propertize " " 'display `((space :align-to (- (+ right right-fringe right-margin) ,(* w right-ratio)))))
+       (awesome-tab-line right-len)))))
+
+(defun awesome-tab-ad-semantic-stickyfunc (orig-fun &rest args)
+  (if awesome-tab-mode
+      (awesome-tab-format-merge (apply orig-fun args) 0.618)
+    (apply orig-fun args)))
+
+(defun awesome-tab-active-semantic-stickyfunc()
+  (advice-add 'semantic-stickyfunc-fetch-stickyline :around #'awesome-tab-ad-semantic-stickyfunc))
+
 (provide 'awesome-tab)
 
 ;;; awesome-tab.el ends here

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -595,7 +595,7 @@ Call `awesome-tab-tab-label-function' to obtain a label for TAB."
            'pointer 'hand)
           ))
 
-(defun awesome-tab-line-format (tabset)
+(defun awesome-tab-line-format (tabset &optional len)
   "Return the `header-line-format' value to display TABSET."
   (let* ((sel (awesome-tab-selected-tab tabset))
          (tabs (awesome-tab-view tabset))
@@ -628,7 +628,8 @@ Call `awesome-tab-tab-label-function' to obtain a label for TAB."
                         (goto-char (point-max))
                         (apply 'insert elts)
                         (goto-char (point-min))
-                        (> (vertical-motion 1) 0)))
+                        (or (> (vertical-motion 1) 0)
+                            (and len (> (point-max) len)))))
             (awesome-tab-scroll tabset 1)
             (setq elts (cdr elts)))))
       (setq elts (nreverse elts))
@@ -647,7 +648,7 @@ Call `awesome-tab-tab-label-function' to obtain a label for TAB."
                        'pointer 'arrow)))
     ))
 
-(defun awesome-tab-line ()
+(defun awesome-tab-line (&optional len)
   "Return the header line templates that represent the tab bar.
 Inhibit display of the tab bar in current window `awesome-tab-hide-tab-function' return nil."
   (cond
@@ -657,7 +658,7 @@ Inhibit display of the tab bar in current window `awesome-tab-hide-tab-function'
    ((awesome-tab-current-tabset t)
     ;; When available, use a cached tab bar value, else recompute it.
     (or (awesome-tab-template awesome-tab-current-tabset)
-        (awesome-tab-line-format awesome-tab-current-tabset)))))
+        (awesome-tab-line-format awesome-tab-current-tabset len)))))
 
 (defconst awesome-tab-header-line-format '(:eval (awesome-tab-line))
   "The tab bar header line format.")


### PR DESCRIPTION
awesome-tab is cool but I miss the semantic-stickfunc.

Here's an attempt to merge them together.

I tried to use awesome-tab-local-mode to honor the semantic-stickfunc by running
awesome-tab-local-mode after semantic-stickfunc in the hook, but it does not
always work. Using advice is neat but not general. That's life.
