### PR TITLE
fix: make it work when background/foreground colors are not specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,15 @@ If you dislike icon render in tab and still need use ```all-the-icons``` plugin,
 you can set variable ```awesome-tab-display-icon``` with nil.
 
 #### Theme
-Tab color will change with current theme, you don't need customize the color tab. 
+Tab color will change with current theme, you don't need customize the color tab.
+
+Emacs may not detect your theme style (light/dark) in the terminal correctly.
+You may need to set `frame-background-mode` manually to have correct tab (and text) colors:
+
+```Elisp
+(when (not (display-graphic-p))
+  (setq frame-background-mode 'dark))
+```
 
 #### TabStyle
 Default tab style is "wave", you can customize option ```awesome-tab-style``` follow your preferences, below are the different tab style screenshots:

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -581,7 +581,7 @@ current cached copy."
   "Blend two colors C1 and C2 with ALPHA.
 C1 and C2 are hexidecimal strings.
 ALPHA is a number between 0.0 and 1.0 which corresponds to the
-infouence of C1 on the result."
+influence of C1 on the result."
   (apply #'(lambda (r g b)
              (format "#%02x%02x%02x"
                      (ash r -8)
@@ -594,10 +594,19 @@ infouence of C1 on the result."
 
 (defun awesome-tab-adjust-color-with-theme ()
   "We need adjust awesome-tab's colors when user switch new theme."
-  (let* ((fg (face-foreground 'default))
-         (bg (face-background 'default))
-         (white "#FFFFFF")
+  (let* ((white "#FFFFFF")
          (black "#000000")
+         (bg-mode (frame-parameter nil 'background-mode))
+         (bg-unspecified (string= (face-background 'default) "unspecified-bg"))
+         (fg-unspecified (string= (face-foreground 'default) "unspecified-fg"))
+         (fg (cond
+              ((and fg-unspecified (eq bg-mode 'dark)) "gray80")
+              ((and fg-unspecified (eq bg-mode 'light)) "gray20")
+              (t (face-foreground 'default))))
+         (bg (cond
+              ((and bg-unspecified (eq bg-mode 'dark)) "gray20")
+              ((and bg-unspecified (eq bg-mode 'light)) "gray80")
+              (t (face-background 'default))))
          ;; for light themes
          (bg-dark (awesome-tab-color-blend black bg 0.1))
          (bg-more-dark (awesome-tab-color-blend black bg 0.25))
@@ -616,7 +625,7 @@ infouence of C1 on the result."
     (awesome-tab-select-separator-style awesome-tab-style)
     ;; Make tab foreground change with theme.
     (cond
-     ((eq (frame-parameter nil 'background-mode) 'dark)
+     ((eq bg-mode 'dark)
       (set-face-attribute 'awesome-tab-unselected nil
                           :background bg-light
                           :foreground fg-dark)


### PR DESCRIPTION
See https://github.com/manateelazycat/awesome-tab/pull/38#issuecomment-507155748. This is because background/foreground colors are not specified in terminal. When this happens, colors of tabs are specified according to `frame-background-mode`.