### PR TITLE
improve ivy interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,15 @@ Note that this function switches to the visible range,
 not the actual logical index position of the current group.
 
 ### Plugins
-If you're helm fans, you need add below code in your helm config,
-
-Then add ```helm-source-awesome-tab-group``` in ```helm-source-list```
+If you're a helm fan, you need to add below code in your helm config,
 
 ```Elisp
 (awesome-tab-build-helm-source)
 ```
 
-Ivy fans can use ```awesome-tab-build-ivy-source```
+Then add ```helm-source-awesome-tab-group``` to ```helm-source-list```.
+
+Ivy fans can use the ```awesome-tab-counsel-switch-group``` function instead.
 
 ### Customize
 

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -1877,18 +1877,17 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
                                   :candidates #'awesome-tab-get-groups
                                   :action '(("Switch to group" . awesome-tab-switch-group))))))
 
-;; Ivy source for switching group in ivy.
-(defvar ivy-source-awesome-tab-group nil)
-
-(defun awesome-tab-build-ivy-source ()
+;;;###autoload
+(defun awesome-tab-counsel-switch-group ()
+  "Switch group of awesome-tab."
   (interactive)
-  (setq ivy-source-awesome-tab-group
-        (when (featurep 'ivy)
-          (require 'ivy)
-          (ivy-read
-           "Awesome-Tab Groups:"
-           (awesome-tab-get-groups)
-           :action #'awesome-tab-switch-group))))
+  (when (featurep 'ivy)
+    (require 'ivy)
+    (ivy-read
+     "Awesome-Tab Groups:"
+     (awesome-tab-get-groups)
+     :action #'awesome-tab-switch-group
+     :caller 'awesome-tab-counsel-switch-group)))
 
 (defun awesome-tab-hide-tab (x)
   (let ((name (format "%s" x)))


### PR DESCRIPTION
- `awesome-tab-build-ivy-source` is removed. I don't know helm but ivy doesn't have a unified source.
- Function was renamed. Usually functions with ivy interface are named `counsel-***`