### PR TITLE
add awesome-tab-show-tab-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ and switches to the tab of the corresponding index.
 Note that this function switches to the visible range,
 not the actual logical index position of the current group.
 
+Set customizable variable `awesome-tab-show-tab-index` to `t` to have the
+number displayed in the tab.
+
 ### Plugins
 If you're a helm fan, you need to add below code in your helm config,
 

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -287,6 +287,11 @@ Set this option with nil if you don't like icon in tab."
   :group 'awesome-tab
   :type 'boolean)
 
+(defcustom awesome-tab-show-tab-index nil
+  "Non-nil to display index in tab."
+  :group 'awesome-tab
+  :type 'boolean)
+
 (defvar awesome-tab-hide-tab-function 'awesome-tab-hide-tab
   "Function to hide tab.
 This fucntion accepet tab name, tab will hide if this function return ni.")
@@ -578,6 +583,16 @@ current cached copy."
   "Face used for the selected tab."
   :group 'awesome-tab)
 
+(defface awesome-tab-unselected-index
+  '((t (:inherit 'awesome-tab-unselected)))
+  "Face used for index on unselected tabs."
+  :group 'awesome-tab)
+
+(defface awesome-tab-selected-index
+  '((t (:inherit 'awesome-tab-selected)))
+  "Face used for index on selected tabs."
+  :group 'awesome-tab)
+
 ;;; Tabs
 ;;
 (defun awesome-tab-make-header-line-mouse-map (mouse function)
@@ -615,6 +630,7 @@ influence of C1 on the result."
               ((and bg-unspecified (eq bg-mode 'dark)) "gray20")
               ((and bg-unspecified (eq bg-mode 'light)) "gray80")
               (t (face-background 'default))))
+         (fg-error (face-foreground 'error))
          ;; for light themes
          (bg-dark (awesome-tab-color-blend black bg 0.1))
          (bg-more-dark (awesome-tab-color-blend black bg 0.25))
@@ -646,7 +662,12 @@ influence of C1 on the result."
                           :foreground fg-light)
       (set-face-attribute 'awesome-tab-selected nil
                           :background bg-more-dark
-                          :foreground fg-more-dark)))))
+                          :foreground fg-more-dark)))
+    ;; Set index faces.
+    (set-face-attribute 'awesome-tab-selected-index nil
+                        :foreground fg-error)
+    (set-face-attribute 'awesome-tab-unselected-index nil
+                        :foreground fg-error)))
 
 (defun awesome-tab-line-format (tabset)
   "Return the `header-line-format' value to display TABSET."
@@ -1416,7 +1437,9 @@ element."
   "Return a label for TAB.
 That is, a string used to represent it on the tab bar."
   (let* ((is-active-tab (awesome-tab-selected-p tab (awesome-tab-current-tabset)))
-         (tab-face (if is-active-tab 'awesome-tab-selected 'awesome-tab-unselected)))
+         (tab-face (if is-active-tab 'awesome-tab-selected 'awesome-tab-unselected))
+         (index-face (if is-active-tab 'awesome-tab-selected-index 'awesome-tab-unselected-index))
+         (current-buffer-index (cl-position tab (awesome-tab-view (awesome-tab-current-tabset t)))))
     (concat
      ;; Tab left edge.
      (awesome-tab-separator-render awesome-tab-style-left tab-face)
@@ -1430,6 +1453,9 @@ That is, a string used to represent it on the tab bar."
                     (awesome-tab-truncate-string  awesome-tab-label-fixed-length bufname)
                   bufname)))
       'face tab-face)
+     ;; Tab index.
+     (when awesome-tab-show-tab-index
+       (propertize (format "%s " (+ current-buffer-index 1)) 'face index-face))
      ;; Tab right edge.
      (awesome-tab-separator-render awesome-tab-style-right tab-face)
      )))


### PR DESCRIPTION
A customizable variable `awesome-tab-show-tab-index` is added. Set to `t` to have index (in the visible range) shown in the tab, making it convenient to use `awesome-tab-select-visible-tab`. Here's the screenshot:

![2019-07-04-141228_826x390_scrot](https://user-images.githubusercontent.com/28714352/60643700-88c55f80-9e66-11e9-9cc0-ae9c340e9336.png)

There are still some things to look into:

- The index face doesn't look right in `doom-nord` theme:

  ![2019-07-04-141238_826x390_scrot](https://user-images.githubusercontent.com/28714352/60643742-a397d400-9e66-11e9-91f0-3275b89d7206.png)

  I assume it's the theme's problem, but it needs to be confirmed.

- When the tabset are longer than one screen, open new buffer / switch to a buffer outside the screen causes the index to not start at 1:

  ![2019-07-04-141352_826x390_scrot](https://user-images.githubusercontent.com/28714352/60643867-08532e80-9e67-11e9-9966-8a68f6251a8c.png)

  It will go back to normal after moving the cursor, but may still cause trouble if the user immediately wants to switch to another tab using `awesome-tab-select-visible-tab`. 

- I personally don't like to have the index shown all the time. I'd like to define a hydra where I can select tabs using number keys, and have index shown when entering it, then have it off when exiting it. So I defined a function like this:

  ``` emacs-lisp
  (defun toki-awesome-tab-show-index ()
   (interactive)
   (setq awesome-tab-show-tab-index t)
   (awesome-tab-display-update))
  ```

  But this doesn't work. Seems like `awesome-tab-display-update` doesn't work as expected, you still have to do something like switch the tab once to have the display refreshed. Is their any generic mechanism to *instantly* refresh the display? This will help solve the last 2 problems, and may save much trouble in the future.