### PR TITLE
implement ace jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,25 @@ git clone --depth=1 https://github.com/manateelazycat/awesome-tab.git
 | awesome-tab-move-current-tab-to-right           | Move current tab to right                                                             |
 | awesome-tab-select-visible-tab                  | Select visible tab with given index                                                   |
 
+#### Ace jump
+
+Call command ```awesome-tab-ace-jump```, and a sequence of 1 or 2 characters will show on tabs in the current tab group. Type them to jump to that tab.
+
+Customize ```awesome-tab-ace-keys``` to specify the used characters. The default value is home row keys, and most of the time you can switch to a tab within 1 char. If you often have more than 9 visible tabs, you can do this:
+
+```Elisp
+(customize-set-variable awesome-tab-ace-keys '(?d ?f ?j ?k))
+```
+
+Then you can access up to 16 tabs within 2 keystrokes of index/middle fingers.
+
+Customize ```awesome-tab-ace-str-style``` to specify the position of ace sequences on the tab. You can choose ```'replace-icon```, ```'left``` or ```'right```.
+
 #### Switch tab with given index
 
 You can bind the number keys to the command ```awesome-tab-select-visible-tab```, such as s-1, s-2, s-3 ... etc.
 
-```
+```Elisp
 (global-set-key (kbd "s-1") 'awesome-tab-select-visible-tab)
 (global-set-key (kbd "s-2") 'awesome-tab-select-visible-tab)
 (global-set-key (kbd "s-3") 'awesome-tab-select-visible-tab)

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -299,6 +299,32 @@ Set this option with nil if you don't like icon in tab."
   :group 'awesome-tab
   :type 'boolean)
 
+(defcustom awesome-tab-ace-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l)
+  "Keys used for `awesome-tab-ace-jump'."
+  :group 'awesome-tab
+  :set #'(lambda (symbol value)
+           (set-default symbol value)
+           (let ((1k-seqs nil)
+                 (2k-seqs nil))
+             (dolist (a value)
+               (dolist (b value)
+                 (push (list a b) 2k-seqs))
+               (push (list a) 1k-seqs))
+             (setq awesome-tab-ace-2-key-seqs (nreverse 2k-seqs))
+             (setq awesome-tab-ace-1-key-seqs (nreverse 1k-seqs))))
+  :type '(repeat :tag "Keys" character))
+
+(defcustom awesome-tab-ace-str-style 'replace-icon
+  "Position of ace strings."
+  :group 'awesome-tab
+  :type '(choice
+          (const :tag "Replace icon" replace-icon)
+          (const :tag "Left" left)
+          (const :tag "Right" right)))
+
+(defvar-local awesome-tab-ace-state nil
+  "Whether current buffer is doing `awesome-tab-ace-jump' or not.")
+
 (defvar awesome-tab-hide-tab-function 'awesome-tab-hide-tab
   "Function to hide tab.
 This fucntion accepet tab name, tab will hide if this function return ni.")
@@ -326,6 +352,12 @@ group.  Notice that it is better that a buffer belongs to one group.")
   "Function to adjust buffer order after switch tab.
 Default is `awesome-tab-adjust-buffer-order', you can write your own rule.")
 
+(defvar awesome-tab-ace-1-key-seqs nil
+  "List of 1-key sequences used by `awesome-tab-ace-jump'")
+
+(defvar awesome-tab-ace-2-key-seqs nil
+  "List of 2-key sequences used by `awesome-tab-ace-jump'")
+
 ;;; Misc.
 ;;
 (eval-and-compile
@@ -348,6 +380,13 @@ When not specified, ELLIPSIS defaults to ‘...’."
   (if (> (length s) len)
       (format "%s%s" (substring s 0 (- len (length ellipsis))) ellipsis)
     (concat s (make-string (- len (length s)) ? ))))
+
+(defun awesome-tab-refresh-display ()
+  "Refresh the display of tabs. Put this in your user-defined hooks to
+make sure the face colors are always right."
+  (interactive)
+  (awesome-tab-map-tabsets (lambda (x) (awesome-tab-set-template x nil)))
+  (awesome-tab-display-update))
 
 ;;; Tab and tab set
 ;;
@@ -580,14 +619,23 @@ current cached copy."
 ;;
 
 (defface awesome-tab-unselected
-  '((t
-     (:height 130)))
+  '((t (:height 130)))
   "Face used for unselected tabs."
   :group 'awesome-tab)
 
 (defface awesome-tab-selected
   '((t (:height 130)))
   "Face used for the selected tab."
+  :group 'awesome-tab)
+
+(defface awesome-tab-unselected-ace-str
+  '((t (:inherit 'awesome-tab-unselected)))
+  "Face used for ace string on unselected tabs."
+  :group 'awesome-tab)
+
+(defface awesome-tab-selected-ace-str
+  '((t (:inherit 'awesome-tab-selected)))
+  "Face used for ace string on selected tabs."
   :group 'awesome-tab)
 
 ;;; Tabs
@@ -627,6 +675,7 @@ influence of C1 on the result."
               ((and bg-unspecified (eq bg-mode 'dark)) "gray20")
               ((and bg-unspecified (eq bg-mode 'light)) "gray80")
               (t (face-background 'default))))
+         (fg-error (face-foreground 'error))
          ;; for light themes
          (bg-dark (awesome-tab-color-blend black bg 0.1))
          (bg-more-dark (awesome-tab-color-blend black bg 0.25))
@@ -658,7 +707,11 @@ influence of C1 on the result."
                           :foreground fg-light)
       (set-face-attribute 'awesome-tab-selected nil
                           :background bg-more-dark
-                          :foreground fg-more-dark)))))
+                          :foreground fg-more-dark)))
+    (set-face-attribute 'awesome-tab-unselected-ace-str nil
+                        :foreground fg-error)
+    (set-face-attribute 'awesome-tab-selected-ace-str nil
+                        :foreground fg-error)))
 
 (defun awesome-tab-line-format (tabset)
   "Return the `header-line-format' value to display TABSET."
@@ -853,7 +906,7 @@ Depend on the setting of the option `awesome-tab-cycle-scope'."
   (let ((km (make-sparse-keymap)))
     (define-key km awesome-tab-prefix-key awesome-tab-prefix-map)
     km)
-  "Keymap to use in  Awesome-Tab mode.")
+  "Keymap to use in Awesome-Tab mode.")
 
 (defvar awesome-tab--global-hlf nil)
 
@@ -1428,14 +1481,29 @@ element."
   "Return a label for TAB.
 That is, a string used to represent it on the tab bar."
   (let* ((is-active-tab (awesome-tab-selected-p tab (awesome-tab-current-tabset)))
-         (tab-face (if is-active-tab 'awesome-tab-selected 'awesome-tab-unselected)))
+         (tab-face (if is-active-tab 'awesome-tab-selected 'awesome-tab-unselected))
+         (ace-str-face (if is-active-tab 'awesome-tab-selected-ace-str
+                         'awesome-tab-unselected-ace-str))
+         (current-buffer-index
+          (cl-position tab (awesome-tab-view awesome-tab-current-tabset)))
+         (ace-str (if awesome-tab-ace-state
+                      (elt ace-strs current-buffer-index) ""))
+         (ace-state awesome-tab-ace-state))
     (concat
      ;; Tab left edge.
      (awesome-tab-separator-render awesome-tab-style-left tab-face)
+     ;; Ace string.
+     (when (and ace-state (eq awesome-tab-ace-str-style 'left))
+       (propertize (format "%s " ace-str) 'face ace-str-face))
      ;; Tab icon.
-     (awesome-tab-icon-for-tab tab tab-face)
+     (if (and ace-state (eq awesome-tab-ace-str-style 'replace-icon))
+         (propertize (format "%s " ace-str) 'face ace-str-face)
+       (awesome-tab-icon-for-tab tab tab-face))
      ;; Tab label.
      (propertize (awesome-tab-tab-name tab) 'face tab-face)
+     ;; Ace string.
+     (when (and ace-state (eq awesome-tab-ace-str-style 'right))
+       (propertize (format " %s" ace-str) 'face ace-str-face))
      ;; Tab right edge.
      (awesome-tab-separator-render awesome-tab-style-right tab-face)
      )))
@@ -1747,8 +1815,7 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
          )))
     ;; Switch to next group if last file killed.
     (when (equal (length extension-names) 1)
-      (awesome-tab-forward-group))
-    ))
+      (awesome-tab-forward-group))))
 
 (defun awesome-tab-select-visible-nth-tab (tab-index)
   "Select visible tab with `tab-index'.
@@ -1780,6 +1847,70 @@ not the actual logical index position of the current group."
          (key-desc (key-description key)))
     (awesome-tab-select-visible-nth-tab
      (string-to-number (nth 1 (split-string key-desc "-"))))))
+
+(defun awesome-tab-build-ace-strs (len nkeys seqs)
+  "Build strings for `awesome-tab-ace-jump'.
+LEN is the number of strings, should be the number of current visible
+tabs. NKEYS should be 1 or 2."
+  (let ((i 0)
+        (str nil))
+    (when (>= nkeys 3)
+      (error "NKEYS should be 1 or 2"))
+    (while (< i len)
+      (push (apply #'string (elt seqs i)) str)
+      (setq i (1+ i)))
+    (nreverse str)))
+
+(defun awesome-tab-ace-jump ()
+  "Jump to a visible tab by 1 or 2 chars."
+  (interactive)
+  (let* ((visible-tabs (awesome-tab-view awesome-tab-current-tabset))
+         (n-visible-tabs (length visible-tabs))
+         (done-flag nil)
+         (i 0)
+         (j 0)
+         (char 0)
+         (chars nil)
+         (rangel 0)
+         (rangeu n-visible-tabs)
+         (nchars (length awesome-tab-ace-keys))
+         (nkeys (cond
+                 ((<= n-visible-tabs nchars) 1)
+                 ((<= n-visible-tabs (* nchars nchars)) 2)
+                 (t (error "Too many visible tabs."))))
+         (visible-seqs
+          (cl-subseq
+           (symbol-value
+            (intern
+             (concat "awesome-tab-ace-" (number-to-string nkeys) "-key-seqs")))
+           0 n-visible-tabs))
+         (ace-strs (awesome-tab-build-ace-strs n-visible-tabs nkeys visible-seqs)))
+    (setq awesome-tab-ace-state t)
+    (awesome-tab-refresh-display)
+    (while (< i nkeys)
+      (while (not done-flag)
+        (setq char (read-key (format "Char %d:" (1+ i))))
+        (let ((current-chars (mapcar #'car visible-seqs)))
+          (when (member char current-chars)
+            (setq done-flag t)
+            (setq rangel (cl-position char current-chars))
+            (setq rangeu (1- (- n-visible-tabs (cl-position char (nreverse current-chars)))))
+            (while (< j rangel)
+              (setcar (nthcdr j visible-seqs) nil)
+              (setq j (1+ j)))
+            (setq j (1+ rangeu))
+            (while (< j n-visible-tabs)
+              (setcar (nthcdr j visible-seqs) nil)
+              (setq j (1+ j)))
+            (setq j 0))))
+      (setq done-flag nil)
+      (setq i (1+ i))
+      (setq visible-seqs (mapcar #'cdr visible-seqs))
+      (setq ace-strs (awesome-tab-build-ace-strs n-visible-tabs nkeys visible-seqs))
+      (awesome-tab-refresh-display))
+    (setq awesome-tab-ace-state nil)
+    (awesome-tab-refresh-display)
+    (awesome-tab-buffer-select-tab (nth rangel visible-tabs))))
 
 ;;;;;;;;;;;;;;;;;;;;;;; Utils functions ;;;;;;;;;;;;;;;;;;;;;;;
 (defun awesome-tab-get-groups ()


### PR DESCRIPTION
之前看不见 ace 序列只能盲操作的问题修复了，现在基本可用。我把剩余的问题一起说了吧，不用翻上一个 PR 了：

- 在 `read-key` 的过程中敲 `C-g` 没法取消，这是刚发现的。我能想到的就是加个判断，不过我一直觉得 `C-g` 是 "通用机制"，不起作用还是挺奇怪的。。
- 需要实现一个 ace 序列默认使用 "error" face 的前景色，但仍允许用户自定义的功能。

剩下的那个任意跳窗口 / tab 的功能，把这个问题解决之后我会以 issue 或 PR 的形式再和您讨论。 

PS: 可以先用[我的 fork](https://github.com/AmaiKinono/awesome-tab/tree/feature/ace-jump) 来测试，不着急合并。