### PR TITLE
add move tab to beginning command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,16 @@ git clone --depth=1 https://github.com/manateelazycat/awesome-tab.git
 | awesome-tab-keep-match-buffers-in-current-group | Keep buffers match extension of current group                                         |
 | awesome-tab-move-current-tab-to-left            | Move current tab to left                                                              |
 | awesome-tab-move-current-tab-to-right           | Move current tab to right                                                             |
+| awesome-tab-move-current-tab-to-beg             | Move current tab to the first position                                                |
 | awesome-tab-select-visible-tab                  | Select visible tab with given index                                                   |
+
+*Tip:* When jumping to a tab far away, think if it will be frequently used. If the answer is yes, move it to the first position. By doing so you keep all your frequently used tabs to be in the first screen, so you have easy access to them.
 
 #### Ace jump
 
 Call command ```awesome-tab-ace-jump```, and a sequence of 1 or 2 characters will show on tabs in the current tab group. Type them to jump to that tab.
 
-Customize ```awesome-tab-ace-keys``` to specify the used characters. The default value is home row keys, and most of the time you can switch to a tab within 1 char. 
+Customize ```awesome-tab-ace-keys``` to specify the used characters. The default value is home row keys, and most of the time you can switch to a tab within 1 char.
 
 Customize ```awesome-tab-ace-str-style``` to specify the position of ace sequences on the tab. You can choose ```'replace-icon```, ```'left``` or ```'right```.
 

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -1772,6 +1772,20 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
       (awesome-tab-set-template bufset nil)
       (awesome-tab-display-update))))
 
+(defun awesome-tab-move-current-tab-to-beg ()
+  "Move current tab to the first position."
+  (interactive)
+  (let* ((bufset (awesome-tab-current-tabset t))
+         (bufs (copy-sequence (awesome-tab-tabs bufset)))
+         (current-tab-index
+          (cl-position (current-buffer) (mapcar #'car bufs)))
+         (current-tab (elt bufs current-tab-index)))
+    (setq bufs (delete current-tab bufs))
+    (push current-tab bufs)
+    (set bufset bufs)
+    (awesome-tab-set-template bufset nil)
+    (awesome-tab-display-update)))
+
 (defun awesome-tab-kill-all-buffers-in-current-group ()
   "Kill all buffers in current group."
   (interactive)


### PR DESCRIPTION
还有一些想商量的：

- 是否需要一个对称的「移动到末尾」命令？我是觉得意义不大，不过可以起到撤回误操作的效果。
- 是否需要一组翻页的命令？我在使用那个 hydra 的时候会觉得翻页比搜索要顺手，不过通常我没有很多 tab，所以移动到开头 / 末尾也是基本一样的效果。
- 是否把 `select-visible-nth-tab` 相关的代码和文档删掉？