### PR TITLE
set padcolor when background color is not specified.

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -764,7 +764,12 @@ influence of C1 on the result."
   ;; Reder tab line.
   (let* ((sel (awesome-tab-selected-tab tabset))
          (tabs (awesome-tab-view tabset))
-         (padcolor (face-background 'default))
+         (bg-mode (frame-parameter nil 'background-mode))
+         (bg-unspecified (string= (face-background 'default) "unspecified-bg"))
+         (padcolor (cond
+                    ((and bg-unspecified (eq bg-mode 'dark)) "gray20")
+                    ((and bg-unspecified (eq bg-mode 'light)) "gray80")
+                    (t (face-background  'default))))
          atsel elts)
     ;; Track the selected tab to ensure it is always visible.
     (when awesome-tab--track-selected


### PR DESCRIPTION
In terminal, when background color is not specified, there's this "- - - - -" pattern:

![image](https://user-images.githubusercontent.com/28714352/63080234-2d14e880-bf73-11e9-8476-6deceda806f6.png)

This patch sets `padcolor` to a suitable gray color when this happens.

**Update:** Do not merge now. Please wait a minute. I think maybe I can just not use padcolor if it doesn't have a value, so the color becomes the terminal background color. I will try to do this in a while.

**Update 2:** I found it can't be easily done. I found this: [%- Constructs](https://www.gnu.org/software/emacs/manual/html_node/elisp/_0025_002dConstructs.html#g_t_0025_002dConstructs), so using `- - - - -` to fill up the modeline/header line is the recommended way, or I have to use like a hundred space character to fill it (I'm not sure if this will cause any side effect). If I leave foreground and background color unspecified, the dashed pattern is still there, and the background is still not the terminal background color. So I guess this patch is the best I can do.

Merge if you like it, but this is actually the issue of some themes, and I don't think awesome-tab should take the responsibility to show it right. So it's up to you.