### PR TITLE
fix: work with lazy loaded all-the-icons, ivy and helm.

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -1581,7 +1581,7 @@ Tab name will truncate if option `awesome-tab-truncate-string' big than zero."
   "When tab buffer's file is exists, use `all-the-icons-icon-for-file' to fetch file icon.
 Otherwise use `all-the-icons-icon-for-buffer' to fetch icon for buffer."
   (when (and awesome-tab-display-icon
-             (featurep 'all-the-icons))
+             (ignore-errors (require 'all-the-icons)))
     (let* ((tab-buffer (car tab))
            (tab-file (buffer-file-name tab-buffer))
            (background (face-background face))
@@ -2086,8 +2086,7 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
 (defun awesome-tab-build-helm-source ()
   (interactive)
   (setq helm-source-awesome-tab-group
-        (when (featurep 'helm)
-          (require 'helm)
+        (when (ignore-errors require 'helm)
           (helm-build-sync-source "Awesome-Tab Group"
                                   :candidates #'awesome-tab-get-groups
                                   :action '(("Switch to group" . awesome-tab-switch-group))))))
@@ -2096,8 +2095,7 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
 (defun awesome-tab-counsel-switch-group ()
   "Switch group of awesome-tab."
   (interactive)
-  (when (featurep 'ivy)
-    (require 'ivy)
+  (when (ignore-errors require 'ivy)
     (ivy-read
      "Awesome-Tab Groups:"
      (awesome-tab-get-groups)


### PR DESCRIPTION
我解释一下：我希望能 lazy load `all-the-icons`，所以做了这样的配置：

``` emacs-lisp
(use-package all-the-icons
  :defer t)
```

意义基本就是调用 `all-the-icons-autoload` 里面的函数时，才会加载 `all-the-icons`。但这让 `awesome-tab` 的图标显示不工作了。我认为这是由于用 `featurep` 判断包是否已经加载，所以 `all-the-icons` 未加载时，`all-the-icons-icon-for-file` 之类的函数永远不会被执行到，于是就不会触发 `all-the-icons` 的加载。

于是改成了现在的逻辑，就是尝试 `require`，如果 `require` 不到则不执行下面的代码。对 `helm` 和 `ivy` 也做了这件事情，以防类似情况发生。搜索以后发现还有一个 `(featurep 'mac)`。由于没有查到 `mac` 这个包是干什么的（怀疑是不是 aquamacs 之类的东西提供的），就没有动它。