### PR TITLE
perf: remove unnucessary "require" expression

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -331,6 +331,7 @@ Sticky function is the function at the top of the current window sticky."
   "Non-nil to display icon in tab, this feature need `all-the-icons' is loaded.
 Set this option with nil if you don't like icon in tab."
   :group 'awesome-tab
+  :require 'all-the-icons
   :type 'boolean)
 
 (defcustom awesome-tab-ace-keys '(?j ?k ?l ?s ?d ?f)
@@ -1595,8 +1596,7 @@ Tab name will truncate if option `awesome-tab-truncate-string' big than zero."
 (defun awesome-tab-icon-for-tab (tab face)
   "When tab buffer's file is exists, use `all-the-icons-icon-for-file' to fetch file icon.
 Otherwise use `all-the-icons-icon-for-buffer' to fetch icon for buffer."
-  (when (and awesome-tab-display-icon
-             (ignore-errors (require 'all-the-icons)))
+  (when awesome-tab-display-icon
     (let* ((tab-buffer (car tab))
            (tab-file (buffer-file-name tab-buffer))
            (background (face-background face))


### PR DESCRIPTION
since https://github.com/manateelazycat/awesome-tab/pull/61, feature is
replaced with require for autoloads. But the former is much faster than
than latter:

(benchmark 1000 '(require 'all-the-icons))"Elapsed time: 11.824975s"
(benchmark 1000 '(provide 'all-the-icons))"Elapsed time: 0.010930s"

If multiple workspaces(either persp or eyebrowser) is switched
frequently, profile-report will tell me that the require expression cost
toom much time. In fact, it just need one "require", but it is executed
many times when switching between dual workspaces.

IMO this require expression should be moved to the ":require" propertity
of awesome-tab-display-icon, so it ensures only one require expression
is executed(when this file is loaded):
> :require
>	VALUE should be a feature symbol.  If you save a value
>	for this option, then when your init file loads the value,
>	it does (require VALUE) first.