### PR TITLE
remove package `cl`

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -15,7 +15,7 @@
 ;;
 ;; Features that might be required by this library:
 ;;
-;; `cl' `cl-lib' `color' `which-func'
+;; `cl-lib' `color' `which-func'
 ;;
 
 ;;; This file is NOT part of GNU Emacs
@@ -255,7 +255,6 @@
 ;;
 
 ;;; Require
-(require 'cl)
 (require 'cl-lib)
 (require 'color)
 


### PR DESCRIPTION
Emacs 27 shows "package 'cl' is deprecated" after startup, and this is caused by awesome-tab. I checked and found the actually used `cl-` functions are covered by `cl-lib`, so `cl` is not needed.