### PR TITLE
fix awesome-tab-counsel-switch-group

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -2181,7 +2181,7 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
 (defun awesome-tab-counsel-switch-group ()
   "Switch group of awesome-tab."
   (interactive)
-  (when (ignore-errors require 'ivy)
+  (when (ignore-errors (require 'ivy))
     (ivy-read
      "Awesome-Tab Groups:"
      (awesome-tab-get-groups)


### PR DESCRIPTION
fixes `ivy` require which was broken in `a7c1eff36a1caa647505d70b2d9901f93c03a925`