### PR TITLE
add: user option for active bar color

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -422,15 +422,15 @@ It will render top-line on tab when you set this variable bigger than 0.9."
   :group 'awesome-tab
   :type 'string)
 
-(defcustom awesome-tab-dark-active-bar-color "#008b8b"
+(defcustom awesome-tab-dark-active-bar-color nil
   "The bar color for active tab in dark theme."
   :group 'awesome-tab
-  :type 'string)
+  :type '(choice (const nil) string))
 
-(defcustom awesome-tab-light-active-bar-color "#55ced1"
+(defcustom awesome-tab-light-active-bar-color nil
   "The bar color for active tab in light theme."
   :group 'awesome-tab
-  :type 'string)
+  :type '(choice (const nil) string))
 
 (defvar-local awesome-tab-ace-state nil
   "Whether current buffer is doing `awesome-tab-ace-jump' or not.")
@@ -1232,8 +1232,10 @@ That is, a string used to represent it on the tab bar."
      " " 'display
      (let ((data (make-list height (make-list width 1)))
            (color (pcase (frame-parameter nil 'background-mode)
-                    ('dark awesome-tab-dark-active-bar-color)
-                    ('light awesome-tab-light-active-bar-color))))
+                    ('dark (or awesome-tab-dark-active-bar-color)
+                           (face-background 'highlight))
+                    ('light (or awesome-tab-light-active-bar-color)
+                            (face-background 'highlight)))))
        (ignore-errors
          (create-image
           (concat

--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -422,6 +422,16 @@ It will render top-line on tab when you set this variable bigger than 0.9."
   :group 'awesome-tab
   :type 'string)
 
+(defcustom awesome-tab-dark-active-bar-color "#008b8b"
+  "The bar color for active tab in dark theme."
+  :group 'awesome-tab
+  :type 'string)
+
+(defcustom awesome-tab-light-active-bar-color "#55ced1"
+  "The bar color for active tab in light theme."
+  :group 'awesome-tab
+  :type 'string)
+
 (defvar-local awesome-tab-ace-state nil
   "Whether current buffer is doing `awesome-tab-ace-jump' or not.")
 
@@ -1221,7 +1231,9 @@ That is, a string used to represent it on the tab bar."
     (propertize
      " " 'display
      (let ((data (make-list height (make-list width 1)))
-           (color (face-foreground 'default)))
+           (color (pcase (frame-parameter nil 'background-mode)
+                    ('dark awesome-tab-dark-active-bar-color)
+                    ('light awesome-tab-light-active-bar-color))))
        (ignore-errors
          (create-image
           (concat


### PR DESCRIPTION
For most themes the `default` face is just white or black, and that's not very fascinating.