### PR TITLE
add user options for foreground color

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -383,6 +383,26 @@ It will render top-line on tab when you set this variable bigger than 0.9."
   :group 'awesome-tab
   :type 'string)
 
+(defcustom awesome-tab-dark-selected-foreground-color nil
+  "Foreground for selected tab in dark theme."
+  :group 'awesome-tab
+  :type '(choice (const nil) string))
+
+(defcustom awesome-tab-dark-unselected-foreground-color nil
+  "Foreground for unselected tab in dark theme."
+  :group 'awesome-tab
+  :type '(choice (const nil) string))
+
+(defcustom awesome-tab-light-selected-foreground-color nil
+  "Foreground for selected tab in light theme."
+  :group 'awesome-tab
+  :type '(choice (const nil) string))
+
+(defcustom awesome-tab-light-unselected-foreground-color nil
+  "Foreground for unselected tab in light theme."
+  :group 'awesome-tab
+  :type '(choice (const nil) string))
+
 (defcustom awesome-tab-terminal-dark-select-background-color "#222222"
   "Select background color for terminal dark mode."
   :group 'awesome-tab
@@ -434,12 +454,14 @@ It will render top-line on tab when you set this variable bigger than 0.9."
   :type '(choice (const nil) string))
 
 (defcustom awesome-tab-dark-unselected-blend 0.8
-  "The blend value for unselected background of dark mode"
+  "The blend value for unselected background of dark mode.
+Lower value means more contrast."
   :group 'awesome-tab
   :type 'float)
 
 (defcustom awesome-tab-light-unselected-blend 0.9
-  "The blend value for unselected background of light mode"
+  "The blend value for unselected background of light mode.
+Lower value means more contrast."
   :group 'awesome-tab
   :type 'float)
 
@@ -846,7 +868,10 @@ influence of C1 on the result."
 (defun awesome-tab-get-select-foreground-color ()
   (let ((bg-mode (frame-parameter nil 'background-mode)))
     (if (display-graphic-p)
-        (face-foreground 'font-lock-doc-face)
+        (cond ((eq bg-mode 'dark) (or awesome-tab-dark-selected-foreground-color
+                                      (face-foreground 'font-lock-doc-face)))
+              ((eq bg-mode 'light) (or awesome-tab-light-selected-foreground-color
+                                       (face-foreground 'font-lock-doc-face))))
       (cond ((eq bg-mode 'dark) awesome-tab-terminal-dark-select-foreground-color)
             ((eq bg-mode 'light) awesome-tab-terminal-light-select-foreground-color))
       )))
@@ -854,7 +879,10 @@ influence of C1 on the result."
 (defun awesome-tab-get-unselect-foreground-color ()
   (let ((bg-mode (frame-parameter nil 'background-mode)))
     (if (display-graphic-p)
-        (face-foreground 'font-lock-comment-face)
+        (cond ((eq bg-mode 'dark) (or awesome-tab-dark-unselected-foreground-color
+                                      (face-foreground 'font-lock-comment-face)))
+              ((eq bg-mode 'light) (or awesome-tab-light-unselected-foreground-color
+                                       (face-foreground 'font-lock-comment-face))))
       (cond ((eq bg-mode 'dark) awesome-tab-terminal-dark-unselect-foreground-color)
             ((eq bg-mode 'light) awesome-tab-terminal-light-unselect-foreground-color))
       )))


### PR DESCRIPTION
Solves https://github.com/manateelazycat/awesome-tab/issues/77.

有一个莫名其妙的 bug 是在 doom-solarized-light 这个主题下，如果 `awesome-tab-unselected-text-blend` 大于或等于 0.4，unselected tabs 的前景色会变成主题的背景色：

![image](https://user-images.githubusercontent.com/28714352/77291020-66d37c00-6d18-11ea-84f1-23ae5de39ab4.png)

只要换成 0.39 问题就会消失。

doom-themes 还有别的问题（跟这个补丁无关）。你可以从截图看到后面有 `- - - - - ` 这样的细线，这是只要加载一次 doom-themes 里的主题之后就会有的。我看到代码里其实处理了这个的前景色，但不知为什么在 doom-themes 里不起作用。