### PR TITLE
set distant-foreground for faces

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -826,9 +826,11 @@ influence of C1 on the result."
 
     (set-face-attribute 'awesome-tab-selected-face nil
                         :foreground (awesome-tab-get-select-foreground-color)
+                        :distant-foreground (awesome-tab-get-select-foreground-color)
                         :background select-tab-background)
     (set-face-attribute 'awesome-tab-unselected-face nil
                         :foreground (awesome-tab-get-unselect-foreground-color)
+                        :distant-foreground (awesome-tab-get-unselect-foreground-color)
                         :background unselect-tab-background)
 
     (set-face-attribute 'awesome-tab-selected-ace-face nil
@@ -928,7 +930,8 @@ influence of C1 on the result."
      (list (nreverse elts)
            (propertize "%-"
                        'face (list :background header-line-color
-                                   :foreground header-line-color)
+                                   :foreground header-line-color
+                                   :distant-foreground header-line-color)
                        'pointer 'arrow)))))
 
 (defun awesome-tab-line ()


### PR DESCRIPTION
解决了部分主题中出现 `- - - - - ` 以及前景色偶尔比较诡异的问题。

原因看[这里](https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html):

> **:distant-foreground**
>
> Alternative foreground color, a string. This is like :foreground but the color is only used as a foreground when the background color is near to the foreground that would have been used. This is useful for example when marking text (i.e., the region face). If the text has a foreground that is visible with the region face, that foreground is used. If the foreground is near the region face background, :distant-foreground is used instead so the text is readable. 

由于部分主题给 header-line face 设置了这个属性，在 tab 的前景色接近背景色的时候它就会起作用，导致我们设置的 foreground 失效。