### PR TITLE
Fix "macro defined too late" error during byte compilation

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -521,6 +521,16 @@ group.  Notice that it is better that a buffer belongs to one group.")
         #'(lambda () (force-window-update (selected-window)))
       'force-mode-line-update)))
 
+(defmacro awesome-tab-kill-buffer-match-rule (match-rule)
+  `(save-excursion
+     (mapc #'(lambda (buffer)
+               (with-current-buffer buffer
+                 (when (string-equal current-group-name (cdr (awesome-tab-selected-tab (awesome-tab-current-tabset t))))
+                   (when (funcall ,match-rule buffer)
+                     (kill-buffer buffer))
+                   )))
+           (buffer-list))))
+
 ;; Copied from s.el
 (defun awesome-tab-truncate-string (len s &optional ellipsis)
   "If S is longer than LEN, cut it down and add ELLIPSIS to the end.
@@ -1771,16 +1781,6 @@ tabs. NKEYS should be 1 or 2."
                   )))
           (buffer-list))
     extension-names))
-
-(defmacro awesome-tab-kill-buffer-match-rule (match-rule)
-  `(save-excursion
-     (mapc #'(lambda (buffer)
-               (with-current-buffer buffer
-                 (when (string-equal current-group-name (cdr (awesome-tab-selected-tab (awesome-tab-current-tabset t))))
-                   (when (funcall ,match-rule buffer)
-                     (kill-buffer buffer))
-                   )))
-           (buffer-list))))
 
 ;;;;;;;;;;;;;;;;;;;;;;; Default configurations ;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
When byte-compiling `awesome-tab.el` a few warnings are reported (I'm using emacs 27.0.91):
```
In toplevel form:
awesome-tab.el:346:20:Warning: assignment to free variable
    ‘awesome-tab-ace-2-key-seqs’
awesome-tab.el:347:20:Warning: assignment to free variable
    ‘awesome-tab-ace-1-key-seqs’

In awesome-tab-set-template:
awesome-tab.el:657:11:Warning: defsubst ‘awesome-tab-set-template’ was used
    before it was defined

In awesome-tab-line-tab:
awesome-tab.el:1232:11:Warning: defsubst ‘awesome-tab-line-tab’ was used
    before it was defined

In awesome-tab-buffer-tab-label:
awesome-tab.el:1258:50:Warning: reference to free variable ‘ace-strs’

In awesome-tab-monitor-window-scroll:
awesome-tab.el:1388:42:Warning: reference to free variable
    ‘awesome-tab-last-sticky-func-name’
awesome-tab.el:1388:21:Warning: assignment to free variable
    ‘awesome-tab-last-sticky-func-name’

In awesome-tab-move-current-tab-to-right:
awesome-tab.el:1529:17:Warning: assignment to free variable ‘the-buffer’
awesome-tab.el:1533:17:Warning: reference to free variable ‘the-buffer’

In awesome-tab-move-current-tab-to-left:
awesome-tab.el:1555:15:Warning: assignment to free variable ‘not-yet-this-buf’
awesome-tab.el:1556:15:Warning: reference to free variable ‘not-yet-this-buf’

In awesome-tab-ace-jump:
awesome-tab.el:1736:27:Warning: assignment to free variable ‘upper-index’
awesome-tab.el:1737:31:Warning: reference to free variable ‘upper-index’

In awesome-tab-get-extensions:
awesome-tab.el:1768:37:Warning: reference to free variable
    ‘current-group-name’

In awesome-tab-kill-buffer-match-rule:
awesome-tab.el:1775:11:Warning: macro ‘awesome-tab-kill-buffer-match-rule’
    defined too late

In end of data:
awesome-tab.el:1925:1:Warning: the following functions are not known to be
    defined: all-the-icons-icon-for-file, all-the-icons-faicon,
    all-the-icons-icon-for-mode, which-function, string-trim,
    helm-build-sync-source, ivy-read
```

The macro `awesome-tab-kill-buffer-match-rule` being defined later than it is used causes errors when trying to use it (#90).
In my case it was calling `awesome-tab-kill-all-buffers-in-current-group` defined in a byte-compiled file that reported `Invalid function: awesome-tab-kill-buffer-match-rule`.


With this PR I move the `awesome-tab-kill-buffer-match-rule` macro from the `Utils` section to the `Misc.` section of the code so that the macro is defined before it is used. Let me know if you are ok with the structure I proposed.

BTW thanks for the project! It works really well.