### PR TITLE
Use tab-line for Emacs 27

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -1898,9 +1898,10 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
      ;; Buffer name not match below blacklist.
      (string-prefix-p "*epc" name)
      (string-prefix-p "*helm" name)
-     (string-prefix-p "*Compile-Log*" name)
      (string-prefix-p "*lsp" name)
-     (string-prefix-p "*flycheck" name)
+     (and (eq awesome-tab-display-line 'header-line)
+          (or (string-prefix-p "*Compile-Log*" name)
+              (string-prefix-p "*Flycheck" name)))
 
      ;; Is not magit buffer.
      (and (string-prefix-p "magit" name)


### PR DESCRIPTION
Emacs 27 has `tab-line` for displaying tabs. A benefit of using it is we can have both `header-line` and `tab-line` displayed. See this:

![image](https://user-images.githubusercontent.com/28714352/97217982-0010c680-1803-11eb-87ff-4351cb67df87.png)

This is `M-x list-packages`. `tab-line` is used to display tabs, and `header-line` is used to display the header of the table. An obvious benefit is we no more need to hide tabs for such buffers, like `*Flycheck Errors*`.

You may want to:

- Test this patch. I didn't test it thoroughly so there may be problems.
- Edit the hide rules. I choose to show tabs in `*Compile-Log*` and `*Flycheck Errors*` buffers. I don't know `*lsp` and `*epc` in your code, maybe they can benefit from this too.