### PR TITLE
Tweak face settings

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -488,14 +488,9 @@ Either `header-line', or `tab-line' for Emacs 27 or above."
                  (const tab-line)))
 
 ;; Clear tab-line's color settings.
-(when (version<= "27.0" emacs-version)
-  (set-face-attribute 'tab-line nil
-                      :inherit 'default
-                      :foreground 'unspecified)
-
-  (face-spec-set awesome-tab-display-line
-                 '((t :inherit 'default))
-                 'face-defface-spec))
+(face-spec-set awesome-tab-display-line
+               '((t :inherit 'default))
+               'face-defface-spec)
 
 (defvar-local awesome-tab-ace-state nil
   "Whether current buffer is doing `awesome-tab-ace-jump' or not.")


### PR DESCRIPTION
The `set-face-attributes` form is not needed.

Besides, there's a little logical inconsistency in this code: If you want to modify `tab-line`, then `awesome-tab-display-line` should be changed to `'tab-line`; if you just want to make sure the display is correct no matter on Emacs 26 or 27, the predicate on Emacs version should be removed. I choose the latter solution.

---

`set-face-attributes` 是不需要的。

此外还有一个小的逻辑问题：如果我们只处理 `tab-line`，那应该直接修改 `'tab-line` 而不是 `awesome-tab-display-line`（因为即使是  Emacs 27，用户可能会自定义成用 `header-line` 显示 tab）；如果我们想保证用户看到的效果是对的，不管是 26 还是 27，那应该把版本的判断拿掉。我选择了后一种做法。