### PR TITLE
Replace helm-build-sync-source with helm-make-source

### DIFF
--- a/awesome-tab.el
+++ b/awesome-tab.el
@@ -1885,9 +1885,9 @@ Other buffer group by `awesome-tab-get-group-name' with project name."
   (interactive)
   (setq helm-source-awesome-tab-group
         (when (ignore-errors (require 'helm))
-          (helm-build-sync-source "Awesome-Tab Group"
-                                  :candidates #'awesome-tab-get-groups
-                                  :action '(("Switch to group" . awesome-tab-switch-group))))))
+          (helm-make-source "Awesome-Tab Group" 'helm-source-sync
+            :candidates #'awesome-tab-get-groups
+            :action '(("Switch to group" . awesome-tab-switch-group))))))
 
 ;;;###autoload
 (defun awesome-tab-counsel-switch-group ()


### PR DESCRIPTION
The macro `helm-build-sync-source` will cause an Invalid function error when compiling byte code:

```
Debugger entered--Lisp error: (invalid-function helm-build-sync-source)
  helm-build-sync-source(\"Awesome-Tab Group\" :candidates awesome-tab-get-groups
  :action ((\"Switch to group\" . awesome-tab-switch-group)))
  awesome-tab-build-helm-source()
  (closure (t) nil (awesome-tab-build-helm-source))()"
```

There are 2 ways to solve it:

1. add `(eval-when-compile  (require 'helm-source nil t))`.
2. replace `helm-build-sync-source` with `helm-make-source`.

See https://github.com/jacktasia/dumb-jump/issues/224 for more infomation.

---

Minimal config to reproduce:

```elisp
(progn
  (toggle-debug-on-error)
  (quelpa '(awesome-tab :repo "manateelazycat/awesome-tab" :fetcher github))
  (require 'awesome-tab)
  (awesome-tab-build-helm-source))
```

- macOS 10.13.6
- Emacs 28.0.50